### PR TITLE
Fix error with auth

### DIFF
--- a/docupdater/lib/config.py
+++ b/docupdater/lib/config.py
@@ -102,7 +102,7 @@ class Config(object):
                 self.filtered_strings.extend(self.filtered_strings.pop(index))
                 self.filtered_strings.insert(index, self.filtered_strings[-1:][0])
         # Filter out no string item
-        self.filtered_strings = [item for item in self.filtered_strings if isinstance(item, bytes)]
+        self.filtered_strings = [item for item in self.filtered_strings if isinstance(item, str)]
         # Added matching for ports
         ports = [string.split(':')[0] for string in self.filtered_strings if ':' in string]
         self.filtered_strings.extend(ports)

--- a/docupdater/lib/config.py
+++ b/docupdater/lib/config.py
@@ -101,6 +101,8 @@ class Config(object):
             if isinstance(value, list) or isinstance(value, tuple):
                 self.filtered_strings.extend(self.filtered_strings.pop(index))
                 self.filtered_strings.insert(index, self.filtered_strings[-1:][0])
+        # Filter out no string item
+        self.filtered_strings = [item for item in self.filtered_strings if isinstance(item, bytes)]
         # Added matching for ports
         ports = [string.split(':')[0] for string in self.filtered_strings if ':' in string]
         self.filtered_strings.extend(ports)


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/local/bin/entrypoint", line 7, in <module>
    main()
  File "/usr/local/lib/python3.7/site-packages/docupdater/docupdater.py", line 179, in main
    cli()
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/docupdater/docupdater.py", line 114, in cli
    config.config_blacklist()  # Configure mask on logger
  File "/usr/local/lib/python3.7/site-packages/docupdater/lib/config.py", line 116, in config_blacklist
    handler.addFilter(BlacklistFilter(set(self.filtered_strings)))
TypeError: unhashable type: 'dict'